### PR TITLE
Use clap's derive feature.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap-num"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e063d263364859dc54fb064cedb7c122740cd4733644b14b176c097f51e8ab7"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -186,6 +196,27 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11611dca53440593f38e6b25ec629de50b14cdfa63adc0fb856115a2c6d97595"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -389,6 +420,12 @@ name = "hashbrown"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -986,6 +1023,8 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "clap-num",
+ "clap_complete",
  "directories",
  "futures",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ include = ["src/**/*"]
 [dependencies]
 base64 = "0.22.1"
 chrono = "0.4.38"
-clap = {version = "4.5.20", features = ["cargo"]}
+clap = { version = "4.5.20", features = ["cargo", "derive"] }
+clap-num = "1.1.1"
+clap_complete = "4.5.37"
 directories = "5.0.1"
 futures = "0.3.31"
 indicatif = "0.17.8"

--- a/src/bin/rawst.rs
+++ b/src/bin/rawst.rs
@@ -1,9 +1,41 @@
-use rawst::cli::parser::init;
+use rawst::cli::args;
+use rawst::cli::args::Command;
+use rawst::cli::parser as not_the_parser;
+use rawst::core::config::Config;
 use rawst::core::errors::RawstErr;
+use rawst::core::io::config_exist;
 
 #[tokio::main]
 async fn main() -> Result<(), RawstErr> {
-    init().await?;
+    if let Some(cmd) = args::get_command() {
+        run(cmd).await?
+    }
 
     Ok(())
+}
+
+pub async fn run(cmd: Command) -> Result<(), RawstErr> {
+    let config = match config_exist() {
+        true => Config::load().await?,
+        false => Config::build().await?,
+    };
+
+    match cmd {
+        Command::Download(args) => {
+            if args.input_file.is_some() {
+                not_the_parser::list_download(args, config).await?;
+            } else {
+                not_the_parser::url_download(args, config).await?;
+            }
+            Ok(())
+        }
+        Command::Resume(args) => {
+            not_the_parser::resume_download(args, config).await?;
+            Ok(())
+        }
+        Command::History(args) => {
+            not_the_parser::display_history(args, config).await?;
+            Ok(())
+        }
+    }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,0 +1,132 @@
+use clap::Args;
+use clap::CommandFactory;
+use clap::Parser;
+use clap::Subcommand;
+use clap_complete::Generator;
+use clap_complete::Shell;
+use clap_num::number_range;
+
+// Commands
+// ========
+
+// NOTE: Misleadingly, Command is a clap Subcommand underneath.
+//       We pretend it's just the command outside this file as
+//       the implementation details shouldn't be leaked.
+/// The Rawst command.
+///
+/// - Download
+/// - Resume
+/// - History
+#[derive(Subcommand, Debug, PartialEq)]
+#[command(name = "rawst-subcommand")]
+pub enum Command {
+    /// Download files
+    Download(DownloadArgs),
+    /// Resume partial downloads
+    Resume(ResumeArgs),
+    /// View download history
+    History(HistoryArgs),
+}
+
+// Subcommands
+// -----------
+
+// Download
+const MAX_DOWNLOAD_THREADS: u8 = 8;
+
+#[derive(Args, Debug, PartialEq)]
+pub struct DownloadArgs {
+    // Configuration
+    /// Maximum amount of threads used to download
+    ///
+    /// Limited to 8 threads to avoid throttling
+    #[arg(
+      short,
+      long,
+      default_value_t=MAX_DOWNLOAD_THREADS,
+      value_parser=limit_max_download_threads
+    )]
+    pub threads: u8,
+
+    // Inputs
+    /// File where to look for download IRIs
+    #[arg(short, long, default_value=None)]
+    pub input_file: Option<String>,
+
+    /// The IRIs to download
+    #[arg()]
+    pub files: Vec<String>,
+
+    // Outputs
+    /// The path to the downloaded files
+    #[arg(long)]
+    pub output_file_path: Vec<String>,
+}
+
+fn limit_max_download_threads(s: &str) -> Result<u8, String> {
+    number_range(s, 0, MAX_DOWNLOAD_THREADS)
+}
+
+// Resume
+#[derive(Args, Debug, PartialEq)]
+pub struct ResumeArgs {
+    /// The Downloads to resume
+    ///
+    /// TODO: Default to resume the last download
+    #[arg()]
+    pub download_ids: Vec<String>,
+}
+
+// History
+#[derive(Args, Debug, PartialEq)]
+pub struct HistoryArgs {}
+
+// Implementation details
+// ----------------------
+
+/// Actual struct handled by clap
+///
+/// Not really what we want to use directly as it has extra noise,
+/// - Autocompletion generation
+/// - Version
+/// - About
+/// - Default subcommand
+#[derive(Parser, Debug, PartialEq)]
+#[command(name = "rawst", version, about, long_about = None)]
+struct Arguments {
+    #[command(subcommand)]
+    command: Option<Command>,
+
+    // Hack to default to `rawst download ...`
+    // The setup to make Download the default subcommand come from,
+    // - https://github.com/clap-rs/clap/discussions/4134#discussioncomment-3511528
+    #[command(flatten)]
+    default_command: Option<DownloadArgs>,
+
+    // If provided, outputs the completion file for given shell
+    #[arg(long = "generate", value_enum)]
+    generator: Option<Shell>,
+}
+
+fn print_completions<G: Generator>(gen: G, cmd: &mut clap::Command) {
+    let cmd_name = cmd.get_name().to_string();
+    clap_complete::generate(gen, cmd, cmd_name, &mut std::io::stdout());
+}
+
+pub fn get_command() -> Option<Command> {
+    let args = Arguments::parse();
+
+    if let Some(generator) = args.generator {
+        let mut cmd = Arguments::command();
+        eprintln!("Generating completion file for {generator:?}...");
+        print_completions(generator, &mut cmd);
+
+        None
+    } else if let Some(default_download) = args.default_command {
+        Some(Command::Download(default_download))
+    } else if let Some(ref _command) = args.command {
+        args.command
+    } else {
+        None
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,1 +1,2 @@
+pub mod args;
 pub mod parser;

--- a/src/core/history.rs
+++ b/src/core/history.rs
@@ -153,38 +153,29 @@ impl HistoryManager {
 
         let json_str = fs::read_to_string(&file_path).unwrap();
 
-        let records: Vec<Record> =
-            serde_json::from_str(&json_str).expect("There are no downloads");
+        let records: Vec<Record> = serde_json::from_str(&json_str).expect("There are no downloads");
 
         for record in records.iter().rev() {
-
             if record.status == "Pending" {
-                return Ok(Some(record.to_owned()))
-
+                return Ok(Some(record.to_owned()));
             }
         }
 
         Ok(None)
-
     }
 
-    pub fn get_record(
-        &self,
-        id: &String,
-    ) -> Result<Option<Record>, RawstErr> {
+    pub fn get_record(&self, id: &String) -> Result<Option<Record>, RawstErr> {
         let file_path = Path::new(&self.history_file_path)
             .join("rawst")
             .join("history.json");
 
         let json_str = fs::read_to_string(&file_path).unwrap();
 
-        let records: Vec<Record> =
-            serde_json::from_str(&json_str).expect("There are no downloads");
+        let records: Vec<Record> = serde_json::from_str(&json_str).expect("There are no downloads");
 
         for record in records {
             if record.id == *id {
-                return Ok(Some(record))
-
+                return Ok(Some(record));
             }
         }
 


### PR DESCRIPTION
This fully embraces clap (#8) . We get
- Argument validation (We used to limit the thread/partition number by hand after program startup, which is kind of annoying as you want to fail early.
- Argument auto-completion.
  - I haven't verified this yet
- Better command structuring


I think a few diffs from `cargo fmt` are snuck here. Do you have a setup that enforces formatting on your end?