### PR TITLE
Use typed IRIs instead of String URLs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,19 +1,31 @@
 # Run clippy
 #
-# https://doc.rust-lang.org/stable/clippy/continuous_integration/github_actions.html
+# https://doc.rust-lang.org/clippy/continuous_integration/github_actions.html
 
-
-on: push
 name: Clippy check
 
-# Make sure CI fails on all warnings, including Clippy lints
+on:
+  push:
+  pull_request:
+
 env:
+  CARGO_TERM_COLOR: always
+  # Make sure CI fails on all warnings, including Clippy lints
   RUSTFLAGS: "-Dwarnings"
+
 
 jobs:
   clippy_check:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          # - stable
+          # - beta
+          - nightly
     steps:
       - uses: actions/checkout@v4
-      - name: Run Clippy
+      - name: Switch to rust nightly
+        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }} && rustup component add clippy
+      - name: Run clippy
         run: cargo clippy --all-targets --all-features

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ jobs:
     name: "Build and Upload Binaries"
     strategy:
       matrix:
+        toolchain:
+          # - stable
+          # - beta
+          - nightly
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+# Run clippy
+#
+# https://doc.rust-lang.org/cargo/guide/continuous-integration.html
+
+name: Cargo Build & Test
+
+on:
+  push:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+
+jobs:
+  build_and_test:
+    name: Rust project - latest
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          # - stable
+          # - beta
+          - nightly
+    steps:
+      - uses: actions/checkout@v4
+      - name: Switch to rust nightly
+        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - name: Build
+        run: cargo build --verbose --all-targets --keep-going
+      - name: Test
+        run: cargo test --verbose --all-targets --no-fail-fast

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,6 +730,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
+name = "iri-string"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0f0a572e8ffe56e2ff4f769f32ffe919282c3916799f8b68688b6030063bea"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,6 +1038,7 @@ dependencies = [
  "directories",
  "futures",
  "indicatif",
+ "iri-string",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ clap_complete = "4.5.37"
 directories = "5.0.1"
 futures = "0.3.31"
 indicatif = "0.17.8"
+iri-string = { version = "0.7.7", features = ["serde"] }
 reqwest = {version= "0.12.9", default-features = false, features = ["stream", "rustls-tls"]}
 serde = {version= "1.0.214", features = ["derive"]}
 serde_json = "1.0.132"

--- a/src/bin/rawst.rs
+++ b/src/bin/rawst.rs
@@ -1,8 +1,9 @@
 use rawst::cli::args;
 use rawst::cli::args::Command;
-use rawst::cli::parser as not_the_parser;
 use rawst::core::config::Config;
+use rawst::core::downloader;
 use rawst::core::errors::RawstErr;
+use rawst::core::history;
 use rawst::core::io::config_exist;
 
 #[tokio::main]
@@ -21,21 +22,8 @@ pub async fn run(cmd: Command) -> Result<(), RawstErr> {
     };
 
     match cmd {
-        Command::Download(args) => {
-            if args.input_file.is_some() {
-                not_the_parser::list_download(args, config).await?;
-            } else {
-                not_the_parser::url_download(args, config).await?;
-            }
-            Ok(())
-        }
-        Command::Resume(args) => {
-            not_the_parser::resume_download(args, config).await?;
-            Ok(())
-        }
-        Command::History(args) => {
-            not_the_parser::display_history(args, config).await?;
-            Ok(())
-        }
+        Command::Download(args) => downloader::download(args, config).await,
+        Command::Resume(args) => downloader::resume_download(args, config).await,
+        Command::History(args) => history::show_history(args, config).await,
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,3 +1,5 @@
+use iri_string::types::IriString;
+
 use clap::Args;
 use clap::CommandFactory;
 use clap::Parser;
@@ -55,7 +57,7 @@ pub struct DownloadArgs {
 
     /// The IRIs to download
     #[arg()]
-    pub files: Vec<String>,
+    pub iris: Vec<IriString>,
 
     // Outputs
     /// The path to the downloaded files

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,2 +1,1 @@
 pub mod args;
-pub mod parser;

--- a/src/core/downloader.rs
+++ b/src/core/downloader.rs
@@ -1,5 +1,4 @@
 use crate::cli::args::DownloadArgs;
-use crate::cli::args::HistoryArgs;
 use crate::cli::args::ResumeArgs;
 use crate::core::config::Config;
 use crate::core::engine::Engine;
@@ -13,8 +12,15 @@ use std::sync::atomic::Ordering;
 use base64::{prelude::BASE64_STANDARD, Engine as Base64Engine};
 use chrono::prelude::Local;
 
-// TODO: Fuse url_download and list_download
-// TODO: Support downloading many elements from each source
+pub async fn download(args: DownloadArgs, config: Config) -> Result<(), RawstErr> {
+    // TODO: Fuse url_download and list_download
+    // TODO: Support downloading many elements from each source
+    if args.input_file.is_some() {
+        list_download(args, config).await
+    } else {
+        url_download(args, config).await
+    }
+}
 
 pub async fn url_download(args: DownloadArgs, mut config: Config) -> Result<(), RawstErr> {
     let url = args.files.into_iter().next().ok_or(RawstErr::InvalidArgs)?;
@@ -79,14 +85,6 @@ pub async fn list_download(args: DownloadArgs, mut config: Config) -> Result<(),
     for id in task_ids.iter() {
         history_manager.update_record(id.clone())?;
     }
-
-    Ok(())
-}
-
-pub async fn display_history(_args: HistoryArgs, config: Config) -> Result<(), RawstErr> {
-    let history_manager = HistoryManager::new(config.config_path);
-
-    history_manager.get_history()?;
 
     Ok(())
 }

--- a/src/core/history.rs
+++ b/src/core/history.rs
@@ -1,3 +1,4 @@
+use crate::cli::args::HistoryArgs;
 use crate::core::config::Config;
 use crate::core::errors::RawstErr;
 use crate::core::task::HttpTask;
@@ -8,6 +9,10 @@ use std::path::Path;
 use chrono::prelude::Local;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+
+pub async fn show_history(_args: HistoryArgs, config: Config) -> Result<(), RawstErr> {
+    HistoryManager::new(config.config_path).get_history()
+}
 
 #[derive(Deserialize, Serialize)]
 struct Downloads {

--- a/src/core/io.rs
+++ b/src/core/io.rs
@@ -185,9 +185,12 @@ pub fn get_cache_sizes(
 }
 
 pub fn config_exist() -> bool {
+    // Defaults to ~/.local/share/rawst/
     let base_path = BaseDirs::new().unwrap().data_local_dir().join("rawst");
 
+    // Defaults to ~/.local/share/rawst/config.toml
     let config_file_path = &base_path.join("config.toml");
+    // Defaults to ~/.local/share/rawst/history.json
     let history_file_path = &base_path.join("history.json");
 
     config_file_path.exists() && history_file_path.exists()

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod downloader;
 pub mod engine;
 pub mod errors;
 pub mod history;

--- a/src/core/task.rs
+++ b/src/core/task.rs
@@ -1,11 +1,12 @@
-use crate::core::utils::FileName;
-
 use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,
 };
 
+use iri_string::types::IriString;
 use reqwest::header::HeaderMap;
+
+use crate::core::utils::FileName;
 
 #[derive(Clone, Debug)]
 pub struct Chunk {
@@ -38,7 +39,7 @@ pub enum ChunkType {
 
 #[derive(Clone, Debug)]
 pub struct HttpTask {
-    pub url: String,
+    pub iri: IriString,
     pub filename: FileName,
     pub total_downloaded: Arc<AtomicU64>,
     pub chunk_data: ChunkType,
@@ -50,7 +51,7 @@ pub struct HttpTask {
 
 impl HttpTask {
     pub fn new(
-        url: String,
+        iri: IriString,
         filename: FileName,
         cached_headers: HeaderMap,
         number_of_chunks: usize,
@@ -62,7 +63,7 @@ impl HttpTask {
         };
 
         HttpTask {
-            url,
+            iri,
             filename,
             headers: cached_headers,
             total_downloaded: Arc::new(AtomicU64::new(0)),

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -25,6 +25,8 @@ pub fn extract_filename_from_url(url: &str) -> FileName {
 
     let path = Path::new(filename.last().unwrap());
 
+    // FIXME: This crashes when there's no extension
+    //   RUST_BACKTRACE=1 cargo run -- http://aoeu.com
     FileName {
         stem: path.file_stem().unwrap().to_str().unwrap().to_string(),
         extension: path.extension().unwrap().to_str().unwrap().to_string(),

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -1,7 +1,8 @@
 use std::fmt;
-use std::path::Path;
+use std::path::PathBuf;
 
-use reqwest::{header::HeaderMap, Url};
+use iri_string::types::IriString;
+use reqwest::header::HeaderMap;
 
 #[derive(Debug, Clone)]
 pub struct FileName {
@@ -15,15 +16,8 @@ impl fmt::Display for FileName {
     }
 }
 
-pub fn extract_filename_from_url(url: &str) -> FileName {
-    let parsed_url = Url::parse(url).expect("Invalid Url");
-
-    let filename = parsed_url
-        .path_segments()
-        .map(|c| c.collect::<Vec<_>>())
-        .unwrap();
-
-    let path = Path::new(filename.last().unwrap());
+pub fn extract_filename_from_url(iri: &IriString) -> FileName {
+    let path = PathBuf::from(iri.path_str());
 
     // FIXME: This crashes when there's no extension
     //   RUST_BACKTRACE=1 cargo run -- http://aoeu.com
@@ -42,9 +36,7 @@ pub fn extract_filename_from_header(headers: &HeaderMap) -> Option<FileName> {
 
             for part in parts {
                 if let Some(filename) = part.trim().strip_prefix("filename=") {
-                    let filename = filename.trim_matches('"');
-
-                    let path = Path::new(filename);
+                    let path = PathBuf::from(filename.trim_matches('"'));
 
                     let file_stem = path.file_stem().unwrap().to_str().unwrap().to_string();
 


### PR DESCRIPTION
There's too many Strings around and they make hard to understand things.

This swaps `Strings` that are IRIs/URLs for `IriString`s to make the types more accurate and gain access to some helpers that were hand-rolled, like for guessing the file name out of a IRI/URL.