### PR TITLE
Use PathBufs instead of Strings.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,19 +1,31 @@
 # Run clippy
 #
-# https://doc.rust-lang.org/stable/clippy/continuous_integration/github_actions.html
+# https://doc.rust-lang.org/clippy/continuous_integration/github_actions.html
 
-
-on: push
 name: Clippy check
 
-# Make sure CI fails on all warnings, including Clippy lints
+on:
+  push:
+  pull_request:
+
 env:
+  CARGO_TERM_COLOR: always
+  # Make sure CI fails on all warnings, including Clippy lints
   RUSTFLAGS: "-Dwarnings"
+
 
 jobs:
   clippy_check:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          # - stable
+          # - beta
+          - nightly
     steps:
       - uses: actions/checkout@v4
-      - name: Run Clippy
+      - name: Switch to rust nightly
+        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }} && rustup component add clippy
+      - name: Run clippy
         run: cargo clippy --all-targets --all-features

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ jobs:
     name: "Build and Upload Binaries"
     strategy:
       matrix:
+        toolchain:
+          # - stable
+          # - beta
+          - nightly
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+# Run clippy
+#
+# https://doc.rust-lang.org/cargo/guide/continuous-integration.html
+
+name: Cargo Build & Test
+
+on:
+  push:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+
+jobs:
+  build_and_test:
+    name: Rust project - latest
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          # - stable
+          # - beta
+          - nightly
+    steps:
+      - uses: actions/checkout@v4
+      - name: Switch to rust nightly
+        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - name: Build
+        run: cargo build --verbose --all-targets --keep-going
+      - name: Test
+        run: cargo test --verbose --all-targets --no-fail-fast

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,6 +730,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
+name = "iri-string"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0f0a572e8ffe56e2ff4f769f32ffe919282c3916799f8b68688b6030063bea"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,6 +1038,7 @@ dependencies = [
  "directories",
  "futures",
  "indicatif",
+ "iri-string",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ clap_complete = "4.5.37"
 directories = "5.0.1"
 futures = "0.3.31"
 indicatif = "0.17.8"
+iri-string = { version = "0.7.7", features = ["serde"] }
 reqwest = {version= "0.12.9", default-features = false, features = ["stream", "rustls-tls"]}
 serde = {version= "1.0.214", features = ["derive"]}
 serde_json = "1.0.132"

--- a/src/bin/rawst.rs
+++ b/src/bin/rawst.rs
@@ -1,8 +1,9 @@
 use rawst::cli::args;
 use rawst::cli::args::Command;
-use rawst::cli::parser as not_the_parser;
 use rawst::core::config::Config;
+use rawst::core::downloader;
 use rawst::core::errors::RawstErr;
+use rawst::core::history;
 use rawst::core::io::config_exist;
 
 #[tokio::main]
@@ -21,21 +22,8 @@ pub async fn run(cmd: Command) -> Result<(), RawstErr> {
     };
 
     match cmd {
-        Command::Download(args) => {
-            if args.input_file.is_some() {
-                not_the_parser::list_download(args, config).await?;
-            } else {
-                not_the_parser::url_download(args, config).await?;
-            }
-            Ok(())
-        }
-        Command::Resume(args) => {
-            not_the_parser::resume_download(args, config).await?;
-            Ok(())
-        }
-        Command::History(args) => {
-            not_the_parser::display_history(args, config).await?;
-            Ok(())
-        }
+        Command::Download(args) => downloader::download(args, config).await,
+        Command::Resume(args) => downloader::resume_download(args, config).await,
+        Command::History(args) => history::show_history(args, config).await,
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use iri_string::types::IriString;
 
 use clap::Args;
@@ -53,7 +55,7 @@ pub struct DownloadArgs {
     // Inputs
     /// File where to look for download IRIs
     #[arg(short, long, default_value=None)]
-    pub input_file: Option<String>,
+    pub input_file: Option<PathBuf>,
 
     /// The IRIs to download
     #[arg()]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,3 +1,5 @@
+use iri_string::types::IriString;
+
 use clap::Args;
 use clap::CommandFactory;
 use clap::Parser;
@@ -55,7 +57,7 @@ pub struct DownloadArgs {
 
     /// The IRIs to download
     #[arg()]
-    pub files: Vec<String>,
+    pub iris: Vec<IriString>,
 
     // Outputs
     /// The path to the downloaded files

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -64,7 +64,7 @@ pub struct DownloadArgs {
     // Outputs
     /// The path to the downloaded files
     #[arg(long)]
-    pub output_file_path: Vec<String>,
+    pub output_file_path: Vec<PathBuf>,
 }
 
 fn limit_max_download_threads(s: &str) -> Result<u8, String> {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,2 +1,1 @@
 pub mod args;
-pub mod parser;

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,6 +1,7 @@
 use crate::core::errors::RawstErr;
 
 use std::path::Path;
+use std::path::PathBuf;
 
 use directories::{BaseDirs, UserDirs};
 use serde::{Deserialize, Serialize};
@@ -10,9 +11,9 @@ use toml;
 
 #[derive(Deserialize, Serialize, Clone)]
 pub struct Config {
-    pub download_path: String,
-    pub cache_path: String,
-    pub config_path: String,
+    pub download_path: PathBuf,
+    pub cache_path: PathBuf,
+    pub config_path: PathBuf,
     pub threads: usize,
 }
 
@@ -24,9 +25,9 @@ impl Default for Config {
         let local_dir = base_dirs.data_local_dir();
 
         Config {
-            download_path: user_dirs.download_dir().unwrap().display().to_string(),
-            cache_path: local_dir.join("rawst").join("cache").display().to_string(),
-            config_path: local_dir.display().to_string(),
+            download_path: user_dirs.download_dir().unwrap().to_path_buf(),
+            cache_path: local_dir.join("rawst").join("cache").to_path_buf(),
+            config_path: local_dir.to_path_buf(),
             threads: 1,
         }
     }

--- a/src/core/downloader.rs
+++ b/src/core/downloader.rs
@@ -1,5 +1,4 @@
 use crate::cli::args::DownloadArgs;
-use crate::cli::args::HistoryArgs;
 use crate::cli::args::ResumeArgs;
 use crate::core::config::Config;
 use crate::core::engine::Engine;
@@ -13,8 +12,15 @@ use std::sync::atomic::Ordering;
 use base64::{prelude::BASE64_STANDARD, Engine as Base64Engine};
 use chrono::prelude::Local;
 
-// TODO: Fuse url_download and list_download
-// TODO: Support downloading many elements from each source
+pub async fn download(args: DownloadArgs, config: Config) -> Result<(), RawstErr> {
+    // TODO: Fuse url_download and list_download
+    // TODO: Support downloading many elements from each source
+    if args.input_file.is_some() {
+        list_download(args, config).await
+    } else {
+        url_download(args, config).await
+    }
+}
 
 pub async fn url_download(args: DownloadArgs, mut config: Config) -> Result<(), RawstErr> {
     let url = args.files.into_iter().next().ok_or(RawstErr::InvalidArgs)?;
@@ -79,14 +85,6 @@ pub async fn list_download(args: DownloadArgs, mut config: Config) -> Result<(),
     for id in task_ids.iter() {
         history_manager.update_record(id.clone())?;
     }
-
-    Ok(())
-}
-
-pub async fn display_history(_args: HistoryArgs, config: Config) -> Result<(), RawstErr> {
-    let history_manager = HistoryManager::new(config.config_path);
-
-    history_manager.get_history()?;
 
     Ok(())
 }

--- a/src/core/downloader.rs
+++ b/src/core/downloader.rs
@@ -115,16 +115,14 @@ pub async fn resume_download(args: ResumeArgs, mut config: Config) -> Result<(),
             if data.status == "Pending" {
                 config.threads = data.threads_used;
 
-                let (file_stem, _) = data.file_name.rsplit_once(".").unwrap();
-
                 let mut engine = Engine::new(config.clone());
 
                 let mut http_task = engine
-                    .create_http_task(data.iri, Some(&file_stem.trim().to_owned()))
+                    .create_http_task(data.iri, Some(&data.file_name))
                     .await?;
 
                 let cache_sizes =
-                    get_cache_sizes(data.file_name, data.threads_used, config).unwrap();
+                    get_cache_sizes(&data.file_name, data.threads_used, config).unwrap();
 
                 http_task.calculate_x_offsets(&cache_sizes);
 

--- a/src/core/history.rs
+++ b/src/core/history.rs
@@ -1,3 +1,4 @@
+use crate::cli::args::HistoryArgs;
 use crate::core::config::Config;
 use crate::core::errors::RawstErr;
 use crate::core::task::HttpTask;
@@ -8,6 +9,10 @@ use std::path::Path;
 use chrono::prelude::Local;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+
+pub async fn show_history(_args: HistoryArgs, config: Config) -> Result<(), RawstErr> {
+    HistoryManager::new(config.config_path).get_history()
+}
 
 #[derive(Deserialize, Serialize)]
 struct Downloads {

--- a/src/core/history.rs
+++ b/src/core/history.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::Path;
+use std::path::PathBuf;
 
 use chrono::prelude::Local;
 use iri_string::types::IriString;
@@ -24,9 +25,9 @@ struct Downloads {
 pub struct Record {
     pub id: String,
     pub iri: IriString,
-    pub file_name: String,
+    pub file_name: PathBuf,
     pub file_size: u64,
-    pub file_location: String,
+    pub file_location: PathBuf,
     pub threads_used: usize,
     pub timestamp: String,
     pub status: String,
@@ -36,9 +37,9 @@ impl Record {
     pub fn new(
         id: String,
         iri: IriString,
-        file_name: String,
+        file_name: PathBuf,
         file_size: u64,
-        file_location: String,
+        file_location: PathBuf,
         threads_used: usize,
     ) -> Record {
         let current_time = Local::now();
@@ -57,11 +58,11 @@ impl Record {
 }
 
 pub struct HistoryManager {
-    pub history_file_path: String,
+    pub history_file_path: PathBuf,
 }
 
 impl HistoryManager {
-    pub fn new(local_dir_path: String) -> Self {
+    pub fn new(local_dir_path: PathBuf) -> Self {
         HistoryManager {
             history_file_path: local_dir_path,
         }
@@ -72,7 +73,7 @@ impl HistoryManager {
             .join("rawst")
             .join("history.json");
 
-        let json_str = fs::read_to_string(&file_path).unwrap_or_else(|_| {
+        let json_str: String = fs::read_to_string(&file_path).unwrap_or_else(|_| {
             panic!(
                 "Couldn't read history database at '{}'.",
                 file_path.display()
@@ -90,7 +91,7 @@ impl HistoryManager {
         let new_record = Record::new(
             id,
             task.iri.clone(),
-            task.filename.to_string(),
+            task.filename.clone(),
             task.content_length(),
             config.download_path.clone(),
             config.threads,

--- a/src/core/io.rs
+++ b/src/core/io.rs
@@ -185,9 +185,12 @@ pub fn get_cache_sizes(
 }
 
 pub fn config_exist() -> bool {
+    // Defaults to ~/.local/share/rawst/
     let base_path = BaseDirs::new().unwrap().data_local_dir().join("rawst");
 
+    // Defaults to ~/.local/share/rawst/config.toml
     let config_file_path = &base_path.join("config.toml");
+    // Defaults to ~/.local/share/rawst/history.json
     let history_file_path = &base_path.join("history.json");
 
     config_file_path.exists() && history_file_path.exists()

--- a/src/core/io.rs
+++ b/src/core/io.rs
@@ -1,10 +1,6 @@
-use crate::core::config::Config;
-use crate::core::errors::RawstErr;
-use crate::core::task::{ChunkType, HttpTask};
-use crate::core::utils::FileName;
-
 use std::fs;
 use std::path::Path;
+use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 
 use directories::BaseDirs;
@@ -13,6 +9,11 @@ use indicatif::ProgressBar;
 use reqwest::Response;
 use tokio::fs::{remove_file, File};
 use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader, BufWriter};
+
+use crate::core::config::Config;
+use crate::core::errors::RawstErr;
+use crate::core::task::{ChunkType, HttpTask};
+use crate::core::utils::FileName;
 
 pub async fn merge_files(filename: &FileName, config: &Config) -> Result<(), RawstErr> {
     let output_path = Path::new(&config.download_path).join(filename.to_string());
@@ -196,7 +197,7 @@ pub fn config_exist() -> bool {
     config_file_path.exists() && history_file_path.exists()
 }
 
-pub async fn read_links(filepath: &String) -> Result<String, RawstErr> {
+pub async fn read_links(filepath: &PathBuf) -> Result<String, RawstErr> {
     let mut file = File::open(filepath).await.map_err(RawstErr::FileError)?;
 
     let mut file_content = String::new();

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod downloader;
 pub mod engine;
 pub mod errors;
 pub mod history;

--- a/src/core/task.rs
+++ b/src/core/task.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,
@@ -5,8 +6,6 @@ use std::sync::{
 
 use iri_string::types::IriString;
 use reqwest::header::HeaderMap;
-
-use crate::core::utils::FileName;
 
 #[derive(Clone, Debug)]
 pub struct Chunk {
@@ -40,7 +39,7 @@ pub enum ChunkType {
 #[derive(Clone, Debug)]
 pub struct HttpTask {
     pub iri: IriString,
-    pub filename: FileName,
+    pub filename: PathBuf,
     pub total_downloaded: Arc<AtomicU64>,
     pub chunk_data: ChunkType,
 
@@ -52,10 +51,12 @@ pub struct HttpTask {
 impl HttpTask {
     pub fn new(
         iri: IriString,
-        filename: FileName,
+        filename: PathBuf,
         cached_headers: HeaderMap,
         number_of_chunks: usize,
     ) -> Self {
+        assert!(filename.is_relative());
+
         let chunk_data = if number_of_chunks == 1 {
             ChunkType::None
         } else {

--- a/src/core/task.rs
+++ b/src/core/task.rs
@@ -1,11 +1,12 @@
-use crate::core::utils::FileName;
-
 use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,
 };
 
+use iri_string::types::IriString;
 use reqwest::header::HeaderMap;
+
+use crate::core::utils::FileName;
 
 #[derive(Clone, Debug)]
 pub struct Chunk {
@@ -38,7 +39,7 @@ pub enum ChunkType {
 
 #[derive(Clone, Debug)]
 pub struct HttpTask {
-    pub url: String,
+    pub iri: IriString,
     pub filename: FileName,
     pub total_downloaded: Arc<AtomicU64>,
     pub chunk_data: ChunkType,
@@ -50,7 +51,7 @@ pub struct HttpTask {
 
 impl HttpTask {
     pub fn new(
-        url: String,
+        iri: IriString,
         filename: FileName,
         cached_headers: HeaderMap,
         number_of_chunks: usize,
@@ -62,7 +63,7 @@ impl HttpTask {
         };
 
         HttpTask {
-            url,
+            iri,
             filename,
             headers: cached_headers,
             total_downloaded: Arc::new(AtomicU64::new(0)),

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -25,6 +25,8 @@ pub fn extract_filename_from_url(url: &str) -> FileName {
 
     let path = Path::new(filename.last().unwrap());
 
+    // FIXME: This crashes when there's no extension
+    //   RUST_BACKTRACE=1 cargo run -- http://aoeu.com
     FileName {
         stem: path.file_stem().unwrap().to_str().unwrap().to_string(),
         extension: path.extension().unwrap().to_str().unwrap().to_string(),

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -1,33 +1,22 @@
-use std::fmt;
+use std::path::Path;
 use std::path::PathBuf;
 
 use iri_string::types::IriString;
 use reqwest::header::HeaderMap;
 
-#[derive(Debug, Clone)]
-pub struct FileName {
-    pub stem: String,
-    pub extension: String,
+pub fn extract_filename_from_url(iri: &IriString) -> PathBuf {
+    // "http://example.com/path/to/file.tar.gz?query#frag"
+    // => "/path/to/file.tar.gz"
+    let full_path = PathBuf::from(iri.path_str());
+    // => "file.tar.gz"
+    let path = PathBuf::from(full_path.file_name().unwrap());
+
+    assert!(path.is_relative());
+
+    path
 }
 
-impl fmt::Display for FileName {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}.{}", self.stem, self.extension)
-    }
-}
-
-pub fn extract_filename_from_url(iri: &IriString) -> FileName {
-    let path = PathBuf::from(iri.path_str());
-
-    // FIXME: This crashes when there's no extension
-    //   RUST_BACKTRACE=1 cargo run -- http://aoeu.com
-    FileName {
-        stem: path.file_stem().unwrap().to_str().unwrap().to_string(),
-        extension: path.extension().unwrap().to_str().unwrap().to_string(),
-    }
-}
-
-pub fn extract_filename_from_header(headers: &HeaderMap) -> Option<FileName> {
+pub fn extract_filename_from_header(headers: &HeaderMap) -> Option<PathBuf> {
     let header_value = headers.get("Content-Disposition");
 
     match header_value {
@@ -37,17 +26,8 @@ pub fn extract_filename_from_header(headers: &HeaderMap) -> Option<FileName> {
             for part in parts {
                 if let Some(filename) = part.trim().strip_prefix("filename=") {
                     let path = PathBuf::from(filename.trim_matches('"'));
-
-                    let file_stem = path.file_stem().unwrap().to_str().unwrap().to_string();
-
-                    let extension = path.extension().unwrap().to_str().unwrap().to_string();
-
-                    let structed_filename = FileName {
-                        stem: file_stem,
-                        extension,
-                    };
-
-                    return Some(structed_filename);
+                    assert!(path.is_relative());
+                    return Some(path);
                 }
             }
 
@@ -55,4 +35,8 @@ pub fn extract_filename_from_header(headers: &HeaderMap) -> Option<FileName> {
         }
         None => None,
     }
+}
+
+pub fn chunk_file_name(filename: &Path, part: usize) -> PathBuf {
+    filename.with_added_extension(format!(".part-{}.tmp", part))
 }

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -1,7 +1,8 @@
 use std::fmt;
-use std::path::Path;
+use std::path::PathBuf;
 
-use reqwest::{header::HeaderMap, Url};
+use iri_string::types::IriString;
+use reqwest::header::HeaderMap;
 
 #[derive(Debug, Clone)]
 pub struct FileName {
@@ -15,15 +16,8 @@ impl fmt::Display for FileName {
     }
 }
 
-pub fn extract_filename_from_url(url: &str) -> FileName {
-    let parsed_url = Url::parse(url).expect("Invalid Url");
-
-    let filename = parsed_url
-        .path_segments()
-        .map(|c| c.collect::<Vec<_>>())
-        .unwrap();
-
-    let path = Path::new(filename.last().unwrap());
+pub fn extract_filename_from_url(iri: &IriString) -> FileName {
+    let path = PathBuf::from(iri.path_str());
 
     // FIXME: This crashes when there's no extension
     //   RUST_BACKTRACE=1 cargo run -- http://aoeu.com
@@ -42,9 +36,7 @@ pub fn extract_filename_from_header(headers: &HeaderMap) -> Option<FileName> {
 
             for part in parts {
                 if let Some(filename) = part.trim().strip_prefix("filename=") {
-                    let filename = filename.trim_matches('"');
-
-                    let path = Path::new(filename);
+                    let path = PathBuf::from(filename.trim_matches('"'));
 
                     let file_stem = path.file_stem().unwrap().to_str().unwrap().to_string();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,4 @@
+#![feature(path_add_extension)]
+
 pub mod cli;
 pub mod core;


### PR DESCRIPTION
(This builds on top of #16 and continues the series of using better types)

This swaps `Strings` that are paths to directories and file names for `PathBuf`.

It's kind of a big change because `Config` was a bit too complicated and unclear on whether you'd get a directory, file path or file name out of things. Now `Config` is initialised right away and the rest of the code just refers to `PathBuf`s in there, which avoids having names generated all over the place and makes debugging easier as dumping Config makes things pretty clear.