### PR TITLE
Add logging module

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,19 +1,31 @@
 # Run clippy
 #
-# https://doc.rust-lang.org/stable/clippy/continuous_integration/github_actions.html
+# https://doc.rust-lang.org/clippy/continuous_integration/github_actions.html
 
-
-on: push
 name: Clippy check
 
-# Make sure CI fails on all warnings, including Clippy lints
+on:
+  push:
+  pull_request:
+
 env:
+  CARGO_TERM_COLOR: always
+  # Make sure CI fails on all warnings, including Clippy lints
   RUSTFLAGS: "-Dwarnings"
+
 
 jobs:
   clippy_check:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          # - stable
+          # - beta
+          - nightly
     steps:
       - uses: actions/checkout@v4
-      - name: Run Clippy
+      - name: Switch to rust nightly
+        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }} && rustup component add clippy
+      - name: Run clippy
         run: cargo clippy --all-targets --all-features

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ jobs:
     name: "Build and Upload Binaries"
     strategy:
       matrix:
+        toolchain:
+          # - stable
+          # - beta
+          - nightly
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+# Run clippy
+#
+# https://doc.rust-lang.org/cargo/guide/continuous-integration.html
+
+name: Cargo Build & Test
+
+on:
+  push:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+
+jobs:
+  build_and_test:
+    name: Rust project - latest
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          # - stable
+          # - beta
+          - nightly
+    steps:
+      - uses: actions/checkout@v4
+      - name: Switch to rust nightly
+        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - name: Build
+        run: cargo build --verbose --all-targets --keep-going
+      - name: Test
+        run: cargo test --verbose --all-targets --no-fail-fast

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,6 +730,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
+name = "iri-string"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0f0a572e8ffe56e2ff4f769f32ffe919282c3916799f8b68688b6030063bea"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,6 +1038,7 @@ dependencies = [
  "directories",
  "futures",
  "indicatif",
+ "iri-string",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
@@ -232,6 +238,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "concolor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b946244a988c390a94667ae0e3958411fa40cc46ea496a929b263d883f5f9c3"
+dependencies = [
+ "bitflags 1.3.2",
+ "concolor-query",
+ "is-terminal",
+]
+
+[[package]]
+name = "concolor-clap"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435ff0007a3bb04099fe1beedc6b76e7dd5340c90b168008ac0d7e87441de1bf"
+dependencies = [
+ "clap",
+ "concolor",
+]
+
+[[package]]
+name = "concolor-query"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
+dependencies = [
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "console"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +339,17 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "fern"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ff9c9d5fb3e6da8ac2f77ab76fe7e8087d512ce095200f8f29ac5b656cf6dc"
+dependencies = [
+ "chrono",
+ "colored",
+ "log",
+]
 
 [[package]]
 name = "fnv"
@@ -434,6 +491,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
 name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +535,12 @@ name = "httparse"
 version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -740,6 +809,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+dependencies = [
+ "hermit-abi 0.4.0",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,7 +858,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "libc",
 ]
 
@@ -831,7 +911,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -1035,10 +1115,14 @@ dependencies = [
  "clap",
  "clap-num",
  "clap_complete",
+ "concolor-clap",
  "directories",
+ "fern",
  "futures",
+ "humantime",
  "indicatif",
  "iri-string",
+ "log",
  "reqwest",
  "serde",
  "serde_json",
@@ -1052,7 +1136,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -1702,6 +1786,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -1725,6 +1818,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -1760,6 +1868,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -1772,6 +1886,12 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -1781,6 +1901,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1802,6 +1928,12 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -1811,6 +1943,12 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1826,6 +1964,12 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -1835,6 +1979,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,14 @@ chrono = "0.4.38"
 clap = { version = "4.5.20", features = ["cargo", "derive"] }
 clap-num = "1.1.1"
 clap_complete = "4.5.37"
+concolor-clap = "0.1.0"
 directories = "5.0.1"
+fern = { version = "0.7.0", features = ["chrono", "colored"] }
 futures = "0.3.31"
+humantime = "2.1.0"
 indicatif = "0.17.8"
 iri-string = { version = "0.7.7", features = ["serde"] }
+log = "0.4.22"
 reqwest = {version= "0.12.9", default-features = false, features = ["stream", "rustls-tls"]}
 serde = {version= "1.0.214", features = ["derive"]}
 serde_json = "1.0.132"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ clap_complete = "4.5.37"
 directories = "5.0.1"
 futures = "0.3.31"
 indicatif = "0.17.8"
+iri-string = { version = "0.7.7", features = ["serde"] }
 reqwest = {version= "0.12.9", default-features = false, features = ["stream", "rustls-tls"]}
 serde = {version= "1.0.214", features = ["derive"]}
 serde_json = "1.0.132"

--- a/src/bin/rawst.rs
+++ b/src/bin/rawst.rs
@@ -1,20 +1,15 @@
 use rawst::cli::args;
+use rawst::cli::args::Arguments;
 use rawst::cli::args::Command;
 use rawst::core::config::Config;
 use rawst::core::downloader;
 use rawst::core::errors::RawstErr;
 use rawst::core::history;
+use rawst::core::logger;
 
 #[tokio::main]
 async fn main() -> Result<(), RawstErr> {
-    if let Some(cmd) = args::get_command() {
-        run(cmd).await?
-    }
-
-    Ok(())
-}
-
-pub async fn run(cmd: Command) -> Result<(), RawstErr> {
+    let args = args::get();
     let config = match Config::load().await {
         Ok(config) => config,
         Err(_) => {
@@ -24,9 +19,26 @@ pub async fn run(cmd: Command) -> Result<(), RawstErr> {
         }
     };
 
-    match cmd {
-        Command::Download(args) => downloader::download(args, config).await,
-        Command::Resume(args) => downloader::resume_download(args, config).await,
-        Command::History(args) => history::show_history(args, config).await,
+    logger::init(&config, &args).map_err(|_| RawstErr::InitilisationError)?;
+
+    log::trace!("Arguments: {args:?}");
+    log::trace!("Config: {config:?}");
+
+    if args.command.is_some() {
+        run(config, args).await?
     }
+
+    Ok(())
+}
+
+async fn run(config: Config, args: Arguments) -> Result<(), RawstErr> {
+    if let Some(cmd) = args.command {
+        match cmd {
+            Command::Download(args) => downloader::download(args, config).await?,
+            Command::Resume(args) => downloader::resume_download(args, config).await?,
+            Command::History(args) => history::show_history(args, config).await?,
+        }
+    }
+
+    Ok(())
 }

--- a/src/bin/rawst.rs
+++ b/src/bin/rawst.rs
@@ -1,8 +1,9 @@
 use rawst::cli::args;
 use rawst::cli::args::Command;
-use rawst::cli::parser as not_the_parser;
 use rawst::core::config::Config;
+use rawst::core::downloader;
 use rawst::core::errors::RawstErr;
+use rawst::core::history;
 use rawst::core::io::config_exist;
 
 #[tokio::main]
@@ -21,21 +22,8 @@ pub async fn run(cmd: Command) -> Result<(), RawstErr> {
     };
 
     match cmd {
-        Command::Download(args) => {
-            if args.input_file.is_some() {
-                not_the_parser::list_download(args, config).await?;
-            } else {
-                not_the_parser::url_download(args, config).await?;
-            }
-            Ok(())
-        }
-        Command::Resume(args) => {
-            not_the_parser::resume_download(args, config).await?;
-            Ok(())
-        }
-        Command::History(args) => {
-            not_the_parser::display_history(args, config).await?;
-            Ok(())
-        }
+        Command::Download(args) => downloader::download(args, config).await,
+        Command::Resume(args) => downloader::resume_download(args, config).await,
+        Command::History(args) => history::show_history(args, config).await,
     }
 }

--- a/src/bin/rawst.rs
+++ b/src/bin/rawst.rs
@@ -4,7 +4,6 @@ use rawst::core::config::Config;
 use rawst::core::downloader;
 use rawst::core::errors::RawstErr;
 use rawst::core::history;
-use rawst::core::io::config_exist;
 
 #[tokio::main]
 async fn main() -> Result<(), RawstErr> {
@@ -16,9 +15,13 @@ async fn main() -> Result<(), RawstErr> {
 }
 
 pub async fn run(cmd: Command) -> Result<(), RawstErr> {
-    let config = match config_exist() {
-        true => Config::load().await?,
-        false => Config::build().await?,
+    let config = match Config::load().await {
+        Ok(config) => config,
+        Err(_) => {
+            let config = Config::default();
+            config.initialise_files().await?;
+            config
+        }
     };
 
     match cmd {

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use iri_string::types::IriString;
 
 use clap::Args;
@@ -53,7 +55,7 @@ pub struct DownloadArgs {
     // Inputs
     /// File where to look for download IRIs
     #[arg(short, long, default_value=None)]
-    pub input_file: Option<String>,
+    pub input_file: Option<PathBuf>,
 
     /// The IRIs to download
     #[arg()]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,3 +1,5 @@
+use iri_string::types::IriString;
+
 use clap::Args;
 use clap::CommandFactory;
 use clap::Parser;
@@ -55,7 +57,7 @@ pub struct DownloadArgs {
 
     /// The IRIs to download
     #[arg()]
-    pub files: Vec<String>,
+    pub iris: Vec<IriString>,
 
     // Outputs
     /// The path to the downloaded files

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -64,7 +64,7 @@ pub struct DownloadArgs {
     // Outputs
     /// The path to the downloaded files
     #[arg(long)]
-    pub output_file_path: Vec<String>,
+    pub output_file_path: Vec<PathBuf>,
 }
 
 fn limit_max_download_threads(s: &str) -> Result<u8, String> {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,2 +1,1 @@
 pub mod args;
-pub mod parser;

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -23,6 +23,8 @@ pub struct Config {
     pub cache_dir: PathBuf,
     /// The history file path ($XDG_CONFIG_HOME/rawst/history.json: ~/.config/rawst/history.json)
     pub history_file_path: PathBuf,
+    /// The history file path ($XDG_CONFIG_HOME/rawst/logs/: ~/.config/rawst/logs/)
+    pub log_dir: PathBuf,
 
     /// The default download path ($XDG_DOWNLOAD_DIR: ~/Downloads/)
     pub download_dir: PathBuf,
@@ -32,22 +34,45 @@ pub struct Config {
     pub threads: usize,
 }
 
+impl Config {
+    pub fn log_file_path(&self) -> PathBuf {
+        let td = format_timedate(chrono::Local::now());
+        let thread_id = std::thread::current().id().as_u64();
+        let run_id = format!("{}-{}", td, thread_id);
+
+        // ~/.cache/rawst/logs/2024-12-31_23:59:59_-07:00-1.log
+        self.log_dir.join(format!("{}.log", run_id))
+    }
+}
+
+fn format_timedate(dt: chrono::DateTime<chrono::Local>) -> String {
+    // "2024-12-31_23:59:59"
+    format!("{}", dt.format("%Y-%m-%d_%H:%M:%S_%Z"))
+}
+
 impl Default for Config {
     fn default() -> Self {
         let user_dirs = UserDirs::new().unwrap();
         let base_dirs = BaseDirs::new().unwrap();
 
+        // ~/.config/rawst/
         let config_dir = base_dirs.config_dir().join("rawst").to_path_buf();
+        // ~/.config/rawst/config.toml
         let config_file_path = config_dir.join("config.toml");
 
+        // ~/.cache/rawst/
         let cache_dir = base_dirs.cache_dir().join("rawst").to_path_buf();
+        // ~/.cache/rawst/history.json
         let history_file_path = cache_dir.join("history.json");
+        // ~/.cache/rawst/logs/
+        let log_dir = cache_dir.join("logs").to_path_buf();
 
         Config {
             config_dir,
             config_file_path,
             cache_dir,
             history_file_path,
+            log_dir,
             download_dir: user_dirs.download_dir().unwrap().to_path_buf(),
 
             threads: 1,
@@ -61,65 +86,69 @@ impl Config {
         let config_dir = base_dirs.config_dir().join("rawst").to_path_buf();
         let config_file_path = config_dir.join("config.toml");
 
+        log::debug!("Loading config from '{config_file_path:?}'");
         let config_str = fs::read_to_string(config_file_path)
             .await
             .map_err(RawstErr::FileError)?;
 
-        let config: Config = toml::from_str(&config_str).unwrap();
+        let config: Config = toml::from_str(&config_str).expect("Failed to read config file");
 
         Ok(config)
     }
 
     pub async fn initialise_files(&self) -> Result<(), RawstErr> {
+        log::debug!("Creating new configuration");
+        println!("Creating new configuration");
         // Configuration
+
+        log::trace!("  Creating configuration files");
+        println!("  Creating configuration files");
         {
+            log::trace!("Creating directory {:?}", &self.config_dir);
             fs::create_dir_all(&self.config_dir)
                 .await
                 .expect("Failed to create config directory");
 
+            log::trace!("Creating file '{:?}'", &self.config_file_path);
             let mut config_file = fs::File::create(&self.config_file_path)
                 .await
                 .map_err(RawstErr::FileError)?;
 
             let config_toml = toml::to_string(&self).unwrap();
+            log::trace!("Writing file {:?}", &self.config_file_path);
             config_file
                 .write_all(config_toml.as_bytes())
                 .await
                 .map_err(RawstErr::FileError)?;
         }
 
-        // Cache
+        log::trace!("  Creating cache files");
+        println!("  Creating cache files");
         {
+            log::trace!("Creating directory '{:?}'", &self.cache_dir);
             fs::create_dir_all(&self.cache_dir)
                 .await
                 .expect("Failed to create cache directory");
+            log::trace!("Creating file {:?}", &self.history_file_path);
             let mut history_file = fs::File::create(&self.history_file_path)
                 .await
                 .map_err(RawstErr::FileError)?;
+            log::trace!("Writing empty list to {:?}", &self.history_file_path);
+            println!("Writing empty list to {:?}", &self.history_file_path);
             history_file
                 .write_all("[\n\n]".as_bytes())
                 .await
                 .map_err(RawstErr::FileError)?;
+
+            println!("  Creating logs directory");
+            {
+                log::trace!("Creating directory '{:?}'", &self.log_dir);
+                fs::create_dir_all(&self.log_dir)
+                    .await
+                    .expect("Failed to create log directory");
+            }
         }
 
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn directories_are_indeed_directories() {
-        let config = Config::default();
-
-        assert!(config.config_dir.is_dir());
-        assert!(config.config_file_path.is_file());
-
-        assert!(config.cache_dir.is_dir());
-        assert!(config.history_file_path.is_file());
-
-        assert!(config.download_dir.is_dir());
     }
 }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,6 +1,7 @@
 use crate::core::errors::RawstErr;
 
 use std::path::Path;
+use std::path::PathBuf;
 
 use directories::{BaseDirs, UserDirs};
 use serde::{Deserialize, Serialize};
@@ -10,9 +11,9 @@ use toml;
 
 #[derive(Deserialize, Serialize, Clone)]
 pub struct Config {
-    pub download_path: String,
-    pub cache_path: String,
-    pub config_path: String,
+    pub download_path: PathBuf,
+    pub cache_path: PathBuf,
+    pub config_path: PathBuf,
     pub threads: usize,
 }
 
@@ -24,9 +25,9 @@ impl Default for Config {
         let local_dir = base_dirs.data_local_dir();
 
         Config {
-            download_path: user_dirs.download_dir().unwrap().display().to_string(),
-            cache_path: local_dir.join("rawst").join("cache").display().to_string(),
-            config_path: local_dir.display().to_string(),
+            download_path: user_dirs.download_dir().unwrap().to_path_buf(),
+            cache_path: local_dir.join("rawst").join("cache").to_path_buf(),
+            config_path: local_dir.to_path_buf(),
             threads: 1,
         }
     }

--- a/src/core/downloader.rs
+++ b/src/core/downloader.rs
@@ -34,7 +34,7 @@ pub async fn url_download(args: DownloadArgs, mut config: Config) -> Result<(), 
 
     let http_task = engine.create_http_task(iri, (&save_as).into()).await?;
 
-    let history_manager = HistoryManager::new(config.config_path.clone());
+    let history_manager = HistoryManager::new(config.history_file_path.clone());
 
     let current_time = Local::now();
 
@@ -54,7 +54,7 @@ pub async fn list_download(args: DownloadArgs, mut config: Config) -> Result<(),
 
     let mut engine = Engine::new(config.clone());
 
-    let history_manager = HistoryManager::new(config.config_path.clone());
+    let history_manager = HistoryManager::new(config.config_dir.clone());
 
     let file_path = args.input_file.ok_or(RawstErr::InvalidArgs)?;
 
@@ -101,7 +101,7 @@ pub async fn resume_download(args: ResumeArgs, mut config: Config) -> Result<(),
         .next()
         .ok_or(RawstErr::InvalidArgs)?;
 
-    let history_manager = HistoryManager::new(config.config_path.clone());
+    let history_manager = HistoryManager::new(config.history_file_path.clone());
 
     let record = if id == "auto" {
         history_manager.get_recent_pending()?

--- a/src/core/downloader.rs
+++ b/src/core/downloader.rs
@@ -1,5 +1,4 @@
 use crate::cli::args::DownloadArgs;
-use crate::cli::args::HistoryArgs;
 use crate::cli::args::ResumeArgs;
 use crate::core::config::Config;
 use crate::core::engine::Engine;
@@ -13,8 +12,15 @@ use std::sync::atomic::Ordering;
 use base64::{prelude::BASE64_STANDARD, Engine as Base64Engine};
 use chrono::prelude::Local;
 
-// TODO: Fuse url_download and list_download
-// TODO: Support downloading many elements from each source
+pub async fn download(args: DownloadArgs, config: Config) -> Result<(), RawstErr> {
+    // TODO: Fuse url_download and list_download
+    // TODO: Support downloading many elements from each source
+    if args.input_file.is_some() {
+        list_download(args, config).await
+    } else {
+        url_download(args, config).await
+    }
+}
 
 pub async fn url_download(args: DownloadArgs, mut config: Config) -> Result<(), RawstErr> {
     let url = args.files.into_iter().next().ok_or(RawstErr::InvalidArgs)?;
@@ -79,14 +85,6 @@ pub async fn list_download(args: DownloadArgs, mut config: Config) -> Result<(),
     for id in task_ids.iter() {
         history_manager.update_record(id.clone())?;
     }
-
-    Ok(())
-}
-
-pub async fn display_history(_args: HistoryArgs, config: Config) -> Result<(), RawstErr> {
-    let history_manager = HistoryManager::new(config.config_path);
-
-    history_manager.get_history()?;
 
     Ok(())
 }

--- a/src/core/downloader.rs
+++ b/src/core/downloader.rs
@@ -115,16 +115,14 @@ pub async fn resume_download(args: ResumeArgs, mut config: Config) -> Result<(),
             if data.status == "Pending" {
                 config.threads = data.threads_used;
 
-                let (file_stem, _) = data.file_name.rsplit_once(".").unwrap();
-
                 let mut engine = Engine::new(config.clone());
 
                 let mut http_task = engine
-                    .create_http_task(data.iri, Some(&file_stem.trim().to_owned()))
+                    .create_http_task(data.iri, Some(&data.file_name))
                     .await?;
 
                 let cache_sizes =
-                    get_cache_sizes(data.file_name, data.threads_used, config).unwrap();
+                    get_cache_sizes(&data.file_name, data.threads_used, config).unwrap();
 
                 http_task.calculate_x_offsets(&cache_sizes);
 

--- a/src/core/downloader.rs
+++ b/src/core/downloader.rs
@@ -16,6 +16,7 @@ use crate::core::task::HttpTask;
 pub async fn download(args: DownloadArgs, config: Config) -> Result<(), RawstErr> {
     // TODO: Fuse url_download and list_download
     // TODO: Support downloading many elements from each source
+    log::trace!("Downloading files ({args:?}, {config:?})");
     if args.input_file.is_some() {
         list_download(args, config).await
     } else {
@@ -95,6 +96,7 @@ pub async fn list_download(args: DownloadArgs, mut config: Config) -> Result<(),
 }
 
 pub async fn resume_download(args: ResumeArgs, mut config: Config) -> Result<(), RawstErr> {
+    log::trace!("Resuming download (args:{args:?}, config:{config:?})");
     let id = args
         .download_ids
         .into_iter()

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -26,6 +26,7 @@ impl Engine {
     }
 
     pub async fn http_download(&self, task: HttpTask) -> Result<(), RawstErr> {
+        log::trace!("Starting HTTP download (task:{task:?})");
         let file_name_str = task.filename.display().to_string();
 
         let progressbar = self
@@ -78,6 +79,7 @@ impl Engine {
         iri: IriString,
         save_as: Option<&PathBuf>,
     ) -> Result<HttpTask, RawstErr> {
+        log::trace!("Creating HTTP download task (iri:{iri:?}, save_as:{save_as:?})");
         let cached_headers = self.http_handler.cache_headers(&iri).await?;
 
         let mut filename = match extract_filename_from_header(&cached_headers) {

--- a/src/core/errors.rs
+++ b/src/core/errors.rs
@@ -5,33 +5,39 @@ use reqwest::Error as ReqwestError;
 
 #[derive(Debug)]
 pub enum RawstErr {
-    HttpError(ReqwestError),
-    FileError(io::Error),
-    Unknown(ReqwestError),
-    InvalidThreadCount,
+    // Startup
+    InitilisationError,
     InvalidArgs,
+    // Download
+    HttpError(ReqwestError),
+    Unknown(ReqwestError),
     BadRequest,
     Unauthorized,
     Forbidden,
     NotFound,
     InternalServerError,
     Unreachable,
+    // Save
+    FileError(io::Error),
 }
 
 impl fmt::Display for RawstErr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            RawstErr::HttpError(err) => write!(f, "HTTP Error: {}", err),
-            RawstErr::FileError(err) => write!(f, "File Error: {}", err),
-            RawstErr::InvalidThreadCount => write!(f, "Invalid number of threads"),
+            // Startup
+            RawstErr::InitilisationError => write!(f, "Initialisation failed."),
             RawstErr::InvalidArgs => write!(f, "Invalid Arguments or No Arguments"),
+            // Download
+            RawstErr::HttpError(err) => write!(f, "HTTP Error: {}", err),
             RawstErr::BadRequest => write!(f, "Bad Request: The server cannot or will not process the request due to something that is perceived to be a client error."),
             RawstErr::Unauthorized => write!(f, "Unauthorized: The request has not been applied because it lacks valid authentication credentials for the target resource."),
             RawstErr::Forbidden => write!(f, "Forbidden: The server understood the request, but it refuses to authorize it."),
             RawstErr::NotFound => write!(f, "Not Found: The server has not found anything matching the Request-URI."),
             RawstErr::InternalServerError => write!(f, "Internal Server Error: The server encountered an unexpected condition which prevented it from fulfilling the request."),
             RawstErr::Unreachable => write!(f, "Unreachable: The request was not able to reach the server"),
-            RawstErr::Unknown(err) => write!(f, "Unknow Error: {}", err)
+            RawstErr::Unknown(err) => write!(f, "Unknow Error: {}", err),
+            // Save
+            RawstErr::FileError(err) => write!(f, "File Error: {}", err),
         }
     }
 }

--- a/src/core/history.rs
+++ b/src/core/history.rs
@@ -1,3 +1,4 @@
+use crate::cli::args::HistoryArgs;
 use crate::core::config::Config;
 use crate::core::errors::RawstErr;
 use crate::core::task::HttpTask;
@@ -8,6 +9,10 @@ use std::path::Path;
 use chrono::prelude::Local;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+
+pub async fn show_history(_args: HistoryArgs, config: Config) -> Result<(), RawstErr> {
+    HistoryManager::new(config.config_path).get_history()
+}
 
 #[derive(Deserialize, Serialize)]
 struct Downloads {

--- a/src/core/history.rs
+++ b/src/core/history.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::Path;
+use std::path::PathBuf;
 
 use chrono::prelude::Local;
 use iri_string::types::IriString;
@@ -24,9 +25,9 @@ struct Downloads {
 pub struct Record {
     pub id: String,
     pub iri: IriString,
-    pub file_name: String,
+    pub file_name: PathBuf,
     pub file_size: u64,
-    pub file_location: String,
+    pub file_location: PathBuf,
     pub threads_used: usize,
     pub timestamp: String,
     pub status: String,
@@ -36,9 +37,9 @@ impl Record {
     pub fn new(
         id: String,
         iri: IriString,
-        file_name: String,
+        file_name: PathBuf,
         file_size: u64,
-        file_location: String,
+        file_location: PathBuf,
         threads_used: usize,
     ) -> Record {
         let current_time = Local::now();
@@ -57,11 +58,11 @@ impl Record {
 }
 
 pub struct HistoryManager {
-    pub history_file_path: String,
+    pub history_file_path: PathBuf,
 }
 
 impl HistoryManager {
-    pub fn new(local_dir_path: String) -> Self {
+    pub fn new(local_dir_path: PathBuf) -> Self {
         HistoryManager {
             history_file_path: local_dir_path,
         }
@@ -72,7 +73,7 @@ impl HistoryManager {
             .join("rawst")
             .join("history.json");
 
-        let json_str = fs::read_to_string(&file_path).unwrap_or_else(|_| {
+        let json_str: String = fs::read_to_string(&file_path).unwrap_or_else(|_| {
             panic!(
                 "Couldn't read history database at '{}'.",
                 file_path.display()
@@ -90,7 +91,7 @@ impl HistoryManager {
         let new_record = Record::new(
             id,
             task.iri.clone(),
-            task.filename.to_string(),
+            task.filename.clone(),
             task.content_length(),
             config.download_path.clone(),
             config.threads,

--- a/src/core/http_handler.rs
+++ b/src/core/http_handler.rs
@@ -29,6 +29,7 @@ impl HttpHandler {
         progressbar: &ProgressBar,
         config: &Config,
     ) -> Result<(), RawstErr> {
+        log::trace!("Starting sequential download (task:{task:?}, config:{config:?})");
         let mut headers = HeaderMap::new();
 
         if let ChunkType::Single(chunk) = &task.chunk_data {
@@ -58,6 +59,7 @@ impl HttpHandler {
         progressbar: &ProgressBar,
         config: &Config,
     ) -> Result<(), RawstErr> {
+        log::trace!("Starting concurrent download (task:{task:?}, config:{config:?})");
         // Creates a stream iter for downloading each chunk separately
         let download_tasks = stream::iter((0..config.threads).map(|i| {
             let client = &self.client;

--- a/src/core/http_handler.rs
+++ b/src/core/http_handler.rs
@@ -46,7 +46,7 @@ impl HttpHandler {
             .map_err(RawstErr::HttpError)?;
 
         if response.status().is_success() {
-            create_file(task, response, progressbar, &config.download_path).await?;
+            create_file(task, response, progressbar, &config.download_dir).await?;
         }
 
         Ok(())
@@ -77,7 +77,7 @@ impl HttpHandler {
                         .map_err(RawstErr::HttpError)?;
 
                     if response.status().is_success() {
-                        create_cache(i, task, response, progressbar, &config.cache_path).await?;
+                        create_cache(i, task, response, progressbar, &config.cache_dir).await?;
                     }
                 }
 

--- a/src/core/io.rs
+++ b/src/core/io.rs
@@ -185,9 +185,12 @@ pub fn get_cache_sizes(
 }
 
 pub fn config_exist() -> bool {
+    // Defaults to ~/.local/share/rawst/
     let base_path = BaseDirs::new().unwrap().data_local_dir().join("rawst");
 
+    // Defaults to ~/.local/share/rawst/config.toml
     let config_file_path = &base_path.join("config.toml");
+    // Defaults to ~/.local/share/rawst/history.json
     let history_file_path = &base_path.join("history.json");
 
     config_file_path.exists() && history_file_path.exists()

--- a/src/core/io.rs
+++ b/src/core/io.rs
@@ -1,10 +1,6 @@
-use crate::core::config::Config;
-use crate::core::errors::RawstErr;
-use crate::core::task::{ChunkType, HttpTask};
-use crate::core::utils::FileName;
-
 use std::fs;
 use std::path::Path;
+use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 
 use directories::BaseDirs;
@@ -13,6 +9,11 @@ use indicatif::ProgressBar;
 use reqwest::Response;
 use tokio::fs::{remove_file, File};
 use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader, BufWriter};
+
+use crate::core::config::Config;
+use crate::core::errors::RawstErr;
+use crate::core::task::{ChunkType, HttpTask};
+use crate::core::utils::FileName;
 
 pub async fn merge_files(filename: &FileName, config: &Config) -> Result<(), RawstErr> {
     let output_path = Path::new(&config.download_path).join(filename.to_string());
@@ -196,7 +197,7 @@ pub fn config_exist() -> bool {
     config_file_path.exists() && history_file_path.exists()
 }
 
-pub async fn read_links(filepath: &String) -> Result<String, RawstErr> {
+pub async fn read_links(filepath: &PathBuf) -> Result<String, RawstErr> {
     let mut file = File::open(filepath).await.map_err(RawstErr::FileError)?;
 
     let mut file_content = String::new();

--- a/src/core/logger.rs
+++ b/src/core/logger.rs
@@ -1,0 +1,70 @@
+use std::sync::LazyLock;
+
+use fern::colors::Color;
+use fern::colors::ColoredLevelConfig;
+
+use crate::cli::args::Arguments;
+use crate::core::config::Config;
+
+fn default_colors() -> ColoredLevelConfig {
+    ColoredLevelConfig::default()
+        .trace(Color::BrightMagenta)
+        .debug(Color::BrightCyan)
+}
+static COLORS: LazyLock<ColoredLevelConfig> = LazyLock::new(default_colors);
+
+fn no_colors() -> ColoredLevelConfig {
+    ColoredLevelConfig::new()
+        .trace(Color::Black)
+        .debug(Color::Black)
+        .info(Color::Black)
+        .warn(Color::Black)
+        .error(Color::Black)
+}
+static NO_COLORS: LazyLock<ColoredLevelConfig> = LazyLock::new(no_colors);
+
+pub fn init(config: &Config, args: &Arguments) -> Result<(), fern::InitError> {
+    let log_file_path = config.log_file_path();
+
+    println!("Initialising logger ({:?})...", log_file_path);
+
+    let colors: &ColoredLevelConfig = match args.color.color {
+        concolor_clap::ColorChoice::Never => &NO_COLORS,
+        _ => &COLORS,
+    };
+
+    fern::Dispatch::new()
+        .chain(
+            // Log file
+            fern::Dispatch::new()
+                .level(args.log_verbosity.unwrap_or(log::LevelFilter::Debug))
+                .format(|out, message, record| {
+                    out.finish(format_args!(
+                        "[{} {} {}] {}",
+                        humantime::format_rfc3339_seconds(std::time::SystemTime::now()),
+                        record.level(),
+                        record.target(),
+                        message
+                    ))
+                })
+                .chain(fern::log_file(log_file_path)?),
+        )
+        .chain(
+            // stdout
+            fern::Dispatch::new()
+                .level(args.verbosity.unwrap_or(log::LevelFilter::Warn))
+                .format(|out, message, record| {
+                    out.finish(format_args!(
+                        "[{} {} {}] {}",
+                        humantime::format_rfc3339_seconds(std::time::SystemTime::now()),
+                        colors.color(record.level()),
+                        record.target(),
+                        message
+                    ))
+                })
+                .chain(std::io::stdout()),
+        )
+        .apply()?;
+
+    Ok(())
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -5,5 +5,6 @@ pub mod errors;
 pub mod history;
 pub mod http_handler;
 pub mod io;
+pub mod logger;
 pub mod task;
 pub mod utils;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod downloader;
 pub mod engine;
 pub mod errors;
 pub mod history;

--- a/src/core/task.rs
+++ b/src/core/task.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,
@@ -5,8 +6,6 @@ use std::sync::{
 
 use iri_string::types::IriString;
 use reqwest::header::HeaderMap;
-
-use crate::core::utils::FileName;
 
 #[derive(Clone, Debug)]
 pub struct Chunk {
@@ -40,7 +39,7 @@ pub enum ChunkType {
 #[derive(Clone, Debug)]
 pub struct HttpTask {
     pub iri: IriString,
-    pub filename: FileName,
+    pub filename: PathBuf,
     pub total_downloaded: Arc<AtomicU64>,
     pub chunk_data: ChunkType,
 
@@ -52,10 +51,12 @@ pub struct HttpTask {
 impl HttpTask {
     pub fn new(
         iri: IriString,
-        filename: FileName,
+        filename: PathBuf,
         cached_headers: HeaderMap,
         number_of_chunks: usize,
     ) -> Self {
+        assert!(filename.is_relative());
+
         let chunk_data = if number_of_chunks == 1 {
             ChunkType::None
         } else {

--- a/src/core/task.rs
+++ b/src/core/task.rs
@@ -1,11 +1,12 @@
-use crate::core::utils::FileName;
-
 use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,
 };
 
+use iri_string::types::IriString;
 use reqwest::header::HeaderMap;
+
+use crate::core::utils::FileName;
 
 #[derive(Clone, Debug)]
 pub struct Chunk {
@@ -38,7 +39,7 @@ pub enum ChunkType {
 
 #[derive(Clone, Debug)]
 pub struct HttpTask {
-    pub url: String,
+    pub iri: IriString,
     pub filename: FileName,
     pub total_downloaded: Arc<AtomicU64>,
     pub chunk_data: ChunkType,
@@ -50,7 +51,7 @@ pub struct HttpTask {
 
 impl HttpTask {
     pub fn new(
-        url: String,
+        iri: IriString,
         filename: FileName,
         cached_headers: HeaderMap,
         number_of_chunks: usize,
@@ -62,7 +63,7 @@ impl HttpTask {
         };
 
         HttpTask {
-            url,
+            iri,
             filename,
             headers: cached_headers,
             total_downloaded: Arc::new(AtomicU64::new(0)),

--- a/src/core/task.rs
+++ b/src/core/task.rs
@@ -36,7 +36,7 @@ pub enum ChunkType {
     None,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct HttpTask {
     pub iri: IriString,
     pub filename: PathBuf,
@@ -46,6 +46,16 @@ pub struct HttpTask {
     // Cached headermap from Head request
     // Efficient for header values retrieval
     headers: HeaderMap,
+}
+
+impl std::fmt::Debug for HttpTask {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "HttpTask{{iri:{}, filename:{:?}, ...}}",
+            self.iri, self.filename
+        )
+    }
 }
 
 impl HttpTask {

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -25,6 +25,8 @@ pub fn extract_filename_from_url(url: &str) -> FileName {
 
     let path = Path::new(filename.last().unwrap());
 
+    // FIXME: This crashes when there's no extension
+    //   RUST_BACKTRACE=1 cargo run -- http://aoeu.com
     FileName {
         stem: path.file_stem().unwrap().to_str().unwrap().to_string(),
         extension: path.extension().unwrap().to_str().unwrap().to_string(),

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -1,33 +1,22 @@
-use std::fmt;
+use std::path::Path;
 use std::path::PathBuf;
 
 use iri_string::types::IriString;
 use reqwest::header::HeaderMap;
 
-#[derive(Debug, Clone)]
-pub struct FileName {
-    pub stem: String,
-    pub extension: String,
+pub fn extract_filename_from_url(iri: &IriString) -> PathBuf {
+    // "http://example.com/path/to/file.tar.gz?query#frag"
+    // => "/path/to/file.tar.gz"
+    let full_path = PathBuf::from(iri.path_str());
+    // => "file.tar.gz"
+    let path = PathBuf::from(full_path.file_name().unwrap());
+
+    assert!(path.is_relative());
+
+    path
 }
 
-impl fmt::Display for FileName {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}.{}", self.stem, self.extension)
-    }
-}
-
-pub fn extract_filename_from_url(iri: &IriString) -> FileName {
-    let path = PathBuf::from(iri.path_str());
-
-    // FIXME: This crashes when there's no extension
-    //   RUST_BACKTRACE=1 cargo run -- http://aoeu.com
-    FileName {
-        stem: path.file_stem().unwrap().to_str().unwrap().to_string(),
-        extension: path.extension().unwrap().to_str().unwrap().to_string(),
-    }
-}
-
-pub fn extract_filename_from_header(headers: &HeaderMap) -> Option<FileName> {
+pub fn extract_filename_from_header(headers: &HeaderMap) -> Option<PathBuf> {
     let header_value = headers.get("Content-Disposition");
 
     match header_value {
@@ -37,17 +26,8 @@ pub fn extract_filename_from_header(headers: &HeaderMap) -> Option<FileName> {
             for part in parts {
                 if let Some(filename) = part.trim().strip_prefix("filename=") {
                     let path = PathBuf::from(filename.trim_matches('"'));
-
-                    let file_stem = path.file_stem().unwrap().to_str().unwrap().to_string();
-
-                    let extension = path.extension().unwrap().to_str().unwrap().to_string();
-
-                    let structed_filename = FileName {
-                        stem: file_stem,
-                        extension,
-                    };
-
-                    return Some(structed_filename);
+                    assert!(path.is_relative());
+                    return Some(path);
                 }
             }
 
@@ -55,4 +35,8 @@ pub fn extract_filename_from_header(headers: &HeaderMap) -> Option<FileName> {
         }
         None => None,
     }
+}
+
+pub fn chunk_file_name(filename: &Path, part: usize) -> PathBuf {
+    filename.with_added_extension(format!(".part-{}.tmp", part))
 }

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -1,7 +1,8 @@
 use std::fmt;
-use std::path::Path;
+use std::path::PathBuf;
 
-use reqwest::{header::HeaderMap, Url};
+use iri_string::types::IriString;
+use reqwest::header::HeaderMap;
 
 #[derive(Debug, Clone)]
 pub struct FileName {
@@ -15,15 +16,8 @@ impl fmt::Display for FileName {
     }
 }
 
-pub fn extract_filename_from_url(url: &str) -> FileName {
-    let parsed_url = Url::parse(url).expect("Invalid Url");
-
-    let filename = parsed_url
-        .path_segments()
-        .map(|c| c.collect::<Vec<_>>())
-        .unwrap();
-
-    let path = Path::new(filename.last().unwrap());
+pub fn extract_filename_from_url(iri: &IriString) -> FileName {
+    let path = PathBuf::from(iri.path_str());
 
     // FIXME: This crashes when there's no extension
     //   RUST_BACKTRACE=1 cargo run -- http://aoeu.com
@@ -42,9 +36,7 @@ pub fn extract_filename_from_header(headers: &HeaderMap) -> Option<FileName> {
 
             for part in parts {
                 if let Some(filename) = part.trim().strip_prefix("filename=") {
-                    let filename = filename.trim_matches('"');
-
-                    let path = Path::new(filename);
+                    let path = PathBuf::from(filename.trim_matches('"'));
 
                     let file_stem = path.file_stem().unwrap().to_str().unwrap().to_string();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,4 @@
+#![feature(path_add_extension)]
+
 pub mod cli;
 pub mod core;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(path_add_extension)]
+#![feature(thread_id_value)]
 
 pub mod cli;
 pub mod core;


### PR DESCRIPTION
(This builds on top of #17)

This adds a somewhat simple logging module that can log to stderr and also to a logging file using different levels.

There's new `--verbosity` and `--log-verbosity` flags to adjust that.

I needed to adjust how we get the initial Arguments+Config so that flags that affect logging are available. Previously the args module hid the real Arguments struct used by `clap` and gave us only the subcommand struct, which other global flags (affecting all sub-commands) unavailable.